### PR TITLE
Add custom token map supplier to enable Conductor to failover to available dynamite servers.  

### DIFF
--- a/server/src/main/java/com/netflix/conductor/server/ConductorServer.java
+++ b/server/src/main/java/com/netflix/conductor/server/ConductorServer.java
@@ -25,6 +25,7 @@ import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.HashSet;
 
 import javax.servlet.DispatcherType;
 import javax.ws.rs.core.MediaType;
@@ -155,7 +156,12 @@ public class ConductorServer {
 			cp.setSocketTimeout(0);
 			cp.setConnectTimeout(0);
 			cp.setMaxConnsPerHost(cc.getIntProperty("workflow.dynomite.connection.maxConnsPerHost", 10));
-			
+		
+                        Set<Host> hosts = new HashSet<Host>(dynoHosts);
+                        logger.info("Getting Custom Map ", customTokenMapSupplier.getTokens(hosts));
+                        logger.info("Getting host1 Map ", customTokenMapSupplier.getTokenForHost(dynoHosts.get(0),hosts));	
+                        logger.info("Getting host2 Map ", customTokenMapSupplier.getTokenForHost(dynoHosts.get(1),hosts));
+                        logger.info("Getting host3 Map ", customTokenMapSupplier.getTokenForHost(dynoHosts.get(2),hosts));
 			jedis = new DynoJedisClient.Builder()
 				.withHostSupplier(hs)
 				.withApplicationName(cc.getAppId())

--- a/server/src/main/java/com/netflix/conductor/server/ConductorServer.java
+++ b/server/src/main/java/com/netflix/conductor/server/ConductorServer.java
@@ -167,6 +167,7 @@ public class ConductorServer {
 		case dynomite:
 			ConnectionPoolConfigurationImpl cp = new ConnectionPoolConfigurationImpl(dynoClusterName).withTokenSupplier(getTokenMapSupplier(dynoHosts)).setLocalRack(cc.getAvailabilityZone()).setLocalDataCenter(cc.getRegion());
 			cp.setMaxConnsPerHost(cc.getIntProperty("workflow.dynomite.connection.maxConnsPerHost", 10));
+			cp.setLoadBalancingStrategy(ConnectionPoolConfiguration.LoadBalancingStrategy.RoundRobin);
 			jedis = new DynoJedisClient.Builder()
 				.withHostSupplier(hs)
 				.withApplicationName(cc.getAppId())

--- a/server/src/main/java/com/netflix/conductor/server/ConductorServer.java
+++ b/server/src/main/java/com/netflix/conductor/server/ConductorServer.java
@@ -25,7 +25,6 @@ import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.ArrayList;

--- a/server/src/main/java/com/netflix/conductor/server/ConductorServer.java
+++ b/server/src/main/java/com/netflix/conductor/server/ConductorServer.java
@@ -167,9 +167,9 @@ public class ConductorServer {
 		case redis:		
 		case dynomite:
 			ConnectionPoolConfigurationImpl cp = new ConnectionPoolConfigurationImpl(dynoClusterName).withTokenSupplier(getTokenMapSupplier()).setLocalRack(cc.getAvailabilityZone()).setLocalDataCenter(cc.getRegion());
-                        cp.setLoadBalancingStrategy(ConnectionPoolConfiguration.LoadBalancingStrategy.RoundRobin);			
-			cp.setSocketTimeout(0);
-			cp.setConnectTimeout(0);
+ //                       cp.setLoadBalancingStrategy(ConnectionPoolConfiguration.LoadBalancingStrategy.RoundRobin);			
+//			cp.setSocketTimeout(0);
+//			cp.setConnectTimeout(0);
 			cp.setMaxConnsPerHost(cc.getIntProperty("workflow.dynomite.connection.maxConnsPerHost", 10));
 		
                         Set<Host> hosts = new HashSet<Host>(dynoHosts);

--- a/server/src/main/java/com/netflix/conductor/server/ConductorServer.java
+++ b/server/src/main/java/com/netflix/conductor/server/ConductorServer.java
@@ -82,6 +82,9 @@ public class ConductorServer {
 	
 	private DB db;
 
+        // Create a TokenMapSupplier using the Dyno hosts provided in config file
+        // Currently the entire token space is allocated to every host, meaning each host is an
+        // exact replica of the data set. 
         private TokenMapSupplier getTokenMapSupplier(List<Host> dynoHosts) {
             Map<Host, HostToken> tokenMap = new HashMap<Host, HostToken>();
 
@@ -165,8 +168,6 @@ public class ConductorServer {
 		case dynomite:
 			ConnectionPoolConfigurationImpl cp = new ConnectionPoolConfigurationImpl(dynoClusterName).withTokenSupplier(getTokenMapSupplier(dynoHosts)).setLocalRack(cc.getAvailabilityZone()).setLocalDataCenter(cc.getRegion());
 			cp.setMaxConnsPerHost(cc.getIntProperty("workflow.dynomite.connection.maxConnsPerHost", 10));
-		
-                        Set<Host> hosts = new HashSet<Host>(dynoHosts);
 			jedis = new DynoJedisClient.Builder()
 				.withHostSupplier(hs)
 				.withApplicationName(cc.getAppId())


### PR DESCRIPTION
Added custom token map supplier based on the Dyno Hosts provided in Conductor config. Currently each server in the configuration is an exact replica of the data set and they occupy the entire token range. Also set load balancing strategy to Round Robin for the dynomite servers. 