### PR TITLE
Search for non-archived workflows and cleanup tasks from ES

### DIFF
--- a/core/src/main/java/com/netflix/conductor/dao/IndexDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/IndexDAO.java
@@ -73,6 +73,13 @@ public interface IndexDAO {
 	 */
 	public void remove(String workflowId);
 
+        /**
+         * Remove the task index
+         * @param taskId Task to be removed
+         */
+        public void removeTask(String taskId);
+
+
 	/**
 	 * Updates the index
 	 * @param workflowInstanceId id of the workflow

--- a/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
+++ b/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
@@ -411,7 +411,7 @@ public class ElasticSearchDAO implements IndexDAO {
 	@Override
 	public SearchResult<String> searchWorkflows(String query, String freeText, int start, int count, List<String> sort) {
 		try {
-                        log.error("Search workflow strings ", freeText)
+                        log.error("Search workflow strings ", freeText);
 			return search(query, start, count, sort, freeText, WORKFLOW_DOC_TYPE);
 			
 		} catch (ParserException e) {

--- a/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
+++ b/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
@@ -453,7 +453,6 @@ public class ElasticSearchDAO implements IndexDAO {
 
                         DeleteRequest req = new DeleteRequest(indexName, TASK_DOC_TYPE, taskId);
                         DeleteResponse response = client.getHighLevelClient().delete(req);
-                        log.error("Remove Task return " + response.getResult());
                         if (response.getResult() != DocWriteResponse.Result.DELETED) {
                                 log.error("Index removal failed - document not found by id " + taskId);
                         }

--- a/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
+++ b/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
@@ -411,7 +411,7 @@ public class ElasticSearchDAO implements IndexDAO {
 	@Override
 	public SearchResult<String> searchWorkflows(String query, String freeText, int start, int count, List<String> sort) {
 		try {
-                        log.error("Search workflow strings ", freeText);
+                        log.error("Search workflow strings FreeText" + freeText + " Query " + query);
 			return search(query, start, count, sort, freeText, WORKFLOW_DOC_TYPE);
 			
 		} catch (ParserException e) {

--- a/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
+++ b/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
@@ -411,6 +411,7 @@ public class ElasticSearchDAO implements IndexDAO {
 	@Override
 	public SearchResult<String> searchWorkflows(String query, String freeText, int start, int count, List<String> sort) {
 		try {
+                        log.error("Search workflow strings ", freeText)
 			return search(query, start, count, sort, freeText, WORKFLOW_DOC_TYPE);
 			
 		} catch (ParserException e) {
@@ -438,6 +439,7 @@ public class ElasticSearchDAO implements IndexDAO {
 			if (response.getResult() == DocWriteResponse.Result.DELETED) {
 				log.error("Index removal failed - document not found by id " + workflowId);
 			}
+                        log.error("Calling remove task from ES by id " + workflowId);
 		} catch (Throwable e) {
 			log.error("Index removal failed failed {}", e.getMessage(), e);
 			Monitors.error(className, "remove");

--- a/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
+++ b/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
@@ -438,7 +438,7 @@ public class ElasticSearchDAO implements IndexDAO {
 
 			DeleteRequest req = new DeleteRequest(indexName, WORKFLOW_DOC_TYPE, workflowId);
 			DeleteResponse response = client.getHighLevelClient().delete(req);
-			if (response.getResult() == DocWriteResponse.Result.DELETED) {
+			if (response.getResult() != DocWriteResponse.Result.DELETED) {
 				log.error("Index removal failed - document not found by id " + workflowId);
 			}
 		} catch (Throwable e) {

--- a/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
+++ b/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
@@ -412,9 +412,8 @@ public class ElasticSearchDAO implements IndexDAO {
 	public SearchResult<String> searchWorkflows(String query, String freeText, int start, int count, List<String> sort) {
 		try {
                         String query_mod;
+                        // Append the query to check for non archived flows
                         query_mod = "(" + query + ")AND(archived!=\"true\")";
-
-                        log.error("Search workflow strings FreeText" + freeText + " Query " + query + " Querymod " + query_mod);
 			return search(query_mod, start, count, sort, freeText, WORKFLOW_DOC_TYPE);
 			
 		} catch (ParserException e) {
@@ -455,7 +454,7 @@ public class ElasticSearchDAO implements IndexDAO {
                         DeleteRequest req = new DeleteRequest(indexName, TASK_DOC_TYPE, taskId);
                         DeleteResponse response = client.getHighLevelClient().delete(req);
                         log.error("Remove Task return " + response.getResult());
-                        if (response.getResult() == DocWriteResponse.Result.DELETED) {
+                        if (response.getResult() != DocWriteResponse.Result.DELETED) {
                                 log.error("Index removal failed - document not found by id " + taskId);
                         }
                 } catch (Throwable e) {

--- a/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
+++ b/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
@@ -411,7 +411,10 @@ public class ElasticSearchDAO implements IndexDAO {
 	@Override
 	public SearchResult<String> searchWorkflows(String query, String freeText, int start, int count, List<String> sort) {
 		try {
-                        log.error("Search workflow strings FreeText" + freeText + " Query " + query);
+                        String query_mod;
+                        query_mod = "(" + query + ")AND(archived!=\"true\")";
+
+                        log.error("Search workflow strings FreeText" + freeText + " Query " + query + " Querymod " + query_mod);
 			return search(query, start, count, sort, freeText, WORKFLOW_DOC_TYPE);
 			
 		} catch (ParserException e) {

--- a/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
+++ b/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
@@ -415,7 +415,7 @@ public class ElasticSearchDAO implements IndexDAO {
                         query_mod = "(" + query + ")AND(archived!=\"true\")";
 
                         log.error("Search workflow strings FreeText" + freeText + " Query " + query + " Querymod " + query_mod);
-			return search(query, start, count, sort, freeText, WORKFLOW_DOC_TYPE);
+			return search(query_mod, start, count, sort, freeText, WORKFLOW_DOC_TYPE);
 			
 		} catch (ParserException e) {
 			throw new ApplicationException(Code.BACKEND_ERROR, e.getMessage(), e);

--- a/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
+++ b/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
@@ -433,7 +433,7 @@ public class ElasticSearchDAO implements IndexDAO {
 	public void remove(String workflowId) {
 		try {
 
-			DeleteRequest req = new DeleteRequest(indexName, WORKFLOW_DOC_TYPE, workflowId);
+			DeleteRequest req = new DeleteRequest(indexName, TASK_DOC_TYPE, workflowId);
 			DeleteResponse response = client.getHighLevelClient().delete(req);
 			if (response.getResult() == DocWriteResponse.Result.DELETED) {
 				log.error("Index removal failed - document not found by id " + workflowId);

--- a/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
+++ b/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticSearchDAO.java
@@ -437,17 +437,32 @@ public class ElasticSearchDAO implements IndexDAO {
 	public void remove(String workflowId) {
 		try {
 
-			DeleteRequest req = new DeleteRequest(indexName, TASK_DOC_TYPE, workflowId);
+			DeleteRequest req = new DeleteRequest(indexName, WORKFLOW_DOC_TYPE, workflowId);
 			DeleteResponse response = client.getHighLevelClient().delete(req);
 			if (response.getResult() == DocWriteResponse.Result.DELETED) {
 				log.error("Index removal failed - document not found by id " + workflowId);
 			}
-                        log.error("Calling remove task from ES by id " + workflowId);
 		} catch (Throwable e) {
 			log.error("Index removal failed failed {}", e.getMessage(), e);
 			Monitors.error(className, "remove");
 		}
 	}
+
+        @Override
+        public void removeTask(String taskId) {
+                try {
+
+                        DeleteRequest req = new DeleteRequest(indexName, TASK_DOC_TYPE, taskId);
+                        DeleteResponse response = client.getHighLevelClient().delete(req);
+                        log.error("Remove Task return " + response.getResult());
+                        if (response.getResult() == DocWriteResponse.Result.DELETED) {
+                                log.error("Index removal failed - document not found by id " + taskId);
+                        }
+                } catch (Throwable e) {
+                        log.error("Index removal failed failed {}", e.getMessage(), e);
+                        Monitors.error(className, "remove");
+                }
+        }
 	
 	// TESTED
 	@Override

--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAO.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAO.java
@@ -396,7 +396,7 @@ public class ElasticSearchDAO implements IndexDAO {
 
 			DeleteRequest req = new DeleteRequest(indexName, WORKFLOW_DOC_TYPE, workflowId);
 			DeleteResponse response = client.delete(req).actionGet();
-			if (response.getResult() == DocWriteResponse.Result.DELETED) {
+			if (response.getResult() != DocWriteResponse.Result.DELETED) {
 				log.error("Index removal failed - document not found by id " + workflowId);
 			}
 		} catch (Throwable e) {
@@ -410,7 +410,7 @@ public class ElasticSearchDAO implements IndexDAO {
 
                         DeleteRequest req = new DeleteRequest(indexName, TASK_DOC_TYPE, taskId);
                         DeleteResponse response = client.delete(req).actionGet();
-                        if (response.getResult() == DocWriteResponse.Result.DELETED) {
+                        if (response.getResult() != DocWriteResponse.Result.DELETED) {
                                 log.error("Index removal failed - document not found by id " + taskId);
                         }
                 } catch (Throwable e) {

--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAO.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAO.java
@@ -404,6 +404,21 @@ public class ElasticSearchDAO implements IndexDAO {
 			Monitors.error(className, "remove");
 		}
 	}
+        @Override
+        public void removeTask(String taskId) {
+                try {
+
+                        DeleteRequest req = new DeleteRequest(indexName, TASK_DOC_TYPE, taskId);
+                        DeleteResponse response = client.delete(req).actionGet();
+                        if (response.getResult() == DocWriteResponse.Result.DELETED) {
+                                log.error("Index removal failed - document not found by id " + taskId);
+                        }
+                } catch (Throwable e) {
+                        log.error("Index removal failed failed {}", e.getMessage(), e);
+                        Monitors.error(className, "removeTask");
+                }
+        }
+
 	
 	@Override
 	public void update(String workflowInstanceId, String[] keys, Object[] values) {

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisExecutionDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisExecutionDAO.java
@@ -243,6 +243,7 @@ public class RedisExecutionDAO extends BaseDynoDAO implements ExecutionDAO {
 		dynoClient.srem(nsKey(TASKS_IN_PROGRESS_STATUS, task.getTaskDefName()), task.getTaskId());
 		dynoClient.del(nsKey(TASK, task.getTaskId()));		
 		dynoClient.zrem(nsKey(TASK_LIMIT_BUCKET, task.getTaskDefName()), task.getTaskId());		
+                indexer.remove(taskId);
 	}
 
 	@Override

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisExecutionDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisExecutionDAO.java
@@ -243,7 +243,7 @@ public class RedisExecutionDAO extends BaseDynoDAO implements ExecutionDAO {
 		dynoClient.srem(nsKey(TASKS_IN_PROGRESS_STATUS, task.getTaskDefName()), task.getTaskId());
 		dynoClient.del(nsKey(TASK, task.getTaskId()));		
 		dynoClient.zrem(nsKey(TASK_LIMIT_BUCKET, task.getTaskDefName()), task.getTaskId());		
-                indexer.remove(taskId);
+                indexer.removeTask(taskId);
 	}
 
 	@Override

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/index/ElasticSearchDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/index/ElasticSearchDAO.java
@@ -408,6 +408,21 @@ public class ElasticSearchDAO implements IndexDAO {
 			Monitors.error(className, "remove");
 		}
 	}
+
+        @Override
+        public void removeTask(String taskId) {
+                try {
+
+                        DeleteRequest req = new DeleteRequest(indexName, TASK_DOC_TYPE, taskId);
+                        DeleteResponse response = client.delete(req).actionGet();
+                        if (!response.isFound()) {
+                                log.error("Index removal failed - document not found by id " + taskId);
+                        }
+                } catch (Throwable e) {
+                        log.error("Index removal failed failed {}", e.getMessage(), e);
+                        Monitors.error(className, "removeTask");
+                }
+        }
 	
 	@Override
 	public void update(String workflowInstanceId, String[] keys, Object[] values) {


### PR DESCRIPTION
The following changes are done

- searchWorkflows API will automatically append "archived!=true" as an "AND" condition to avoid getting workflows from ES that are archived
- add API removeTask to indexer and call that when removing tasks from Redis during workflow cleanup
- the API remove which removes workflows was checking if response is DELETE to throw error, which is incorrect. DELETE is the response when ES has successfully deleted something. 