### PR TITLE
Use single shard for dynoQ and truncate archive data to 32K

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowSweeper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowSweeper.java
@@ -105,7 +105,6 @@ public class WorkflowSweeper {
 			Future<?> future = es.submit(() -> {
 				try {
 					
-			        logger.info("Running sweeper for workflow {}", workflowId);
 					WorkflowContext ctx = new WorkflowContext(config.getAppId());
 					WorkflowContext.set(ctx);
 					if(logger.isDebugEnabled()) {

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisExecutionDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisExecutionDAO.java
@@ -56,6 +56,7 @@ public class RedisExecutionDAO extends BaseDynoDAO implements ExecutionDAO {
 	
 	private static final String ARCHIVED_FIELD = "archived";
 	private static final String RAW_JSON_FIELD = "rawJSON";
+        private static final int MAX_RAW_JSON = 1024 * 32 - 10; // Based on string limit in Elastic Search 
 	// Keys Families
 	private static final String TASK_LIMIT_BUCKET = "TASK_LIMIT_BUCKET";
 	private final static String IN_PROGRESS_TASKS = "IN_PROGRESS_TASKS";
@@ -312,9 +313,9 @@ public class RedisExecutionDAO extends BaseDynoDAO implements ExecutionDAO {
 		try {
 			
 			Workflow wf = getWorkflow(workflowId, true);
-			
+                        String rawJson = om.writeValueAsString(wf).substring(0, MAX_RAW_JSON); 
 			//Add to elasticsearch
-			indexer.update(workflowId, new String[]{RAW_JSON_FIELD, ARCHIVED_FIELD}, new Object[]{om.writeValueAsString(wf), true});
+			indexer.update(workflowId, new String[]{RAW_JSON_FIELD, ARCHIVED_FIELD}, new Object[]{rawJson, true});
 			
 			// Remove from lists
 			String key = nsKey(WORKFLOW_DEF_TO_WORKFLOWS, wf.getWorkflowType(), dateStr(wf.getCreateTime()));

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisExecutionDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisExecutionDAO.java
@@ -313,7 +313,11 @@ public class RedisExecutionDAO extends BaseDynoDAO implements ExecutionDAO {
 		try {
 			
 			Workflow wf = getWorkflow(workflowId, true);
-                        String rawJson = om.writeValueAsString(wf).substring(0, MAX_RAW_JSON); 
+                        
+                        String rawJson = om.writeValueAsString(wf);
+                        if (rawJson.length() > MAX_RAW_JSON) {
+                            rawJson = rawJson.substring(0, MAX_RAW_JSON); 
+                        }
 			//Add to elasticsearch
 			indexer.update(workflowId, new String[]{RAW_JSON_FIELD, ARCHIVED_FIELD}, new Object[]{rawJson, true});
 			

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/queue/DynoQueueDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/queue/DynoQueueDAO.java
@@ -96,7 +96,7 @@ public class DynoQueueDAO implements QueueDAO {
 		}
 		
 		localDC = localDC.replaceAll(region, "");
-		this.ss = new SingleShardSupplier("x");
+		this.ss = new SingleShardSupplier("custom");
 		init();
 	}
 

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/queue/DynoQueueDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/queue/DynoQueueDAO.java
@@ -38,7 +38,7 @@ import com.netflix.dyno.jedis.DynoJedisClient;
 import com.netflix.dyno.queues.DynoQueue;
 import com.netflix.dyno.queues.Message;
 import com.netflix.dyno.queues.ShardSupplier;
-import com.netflix.dyno.queues.redis.DynoShardSupplier;
+import com.netflix.dyno.queues.redis.SingleShardSupplier;
 import com.netflix.dyno.queues.redis.RedisDynoQueue;
 import com.netflix.dyno.queues.redis.RedisQueues;
 
@@ -96,7 +96,7 @@ public class DynoQueueDAO implements QueueDAO {
 		}
 		
 		localDC = localDC.replaceAll(region, "");
-		this.ss = new DynoShardSupplier(dyno.getConnPool().getConfiguration().getHostSupplier(), region, localDC);
+		this.ss = new SingleShardSupplier("x");
 		init();
 	}
 

--- a/server/src/main/java/com/netflix/conductor/server/ServerModule.java
+++ b/server/src/main/java/com/netflix/conductor/server/ServerModule.java
@@ -43,7 +43,7 @@ import com.netflix.conductor.dao.esrest.index.ElasticSearchDAO;
 import com.netflix.conductor.dao.esrest.index.ElasticsearchModule;
 import com.netflix.conductor.dao.mysql.MySQLWorkflowModule;
 import com.netflix.dyno.connectionpool.HostSupplier;
-import com.netflix.dyno.queues.redis.DynoShardSupplier;
+import com.netflix.dyno.queues.redis.SingleShardSupplier;
 
 import redis.clients.jedis.JedisCommands;
 
@@ -91,7 +91,7 @@ public class ServerModule extends AbstractModule {
 		} else {
 			String localDC = localRack;
 			localDC = localDC.replaceAll(region, "");
-			DynoShardSupplier ss = new DynoShardSupplier(hs, region, localDC);
+			SingleShardSupplier ss = new SingleShardSupplier("custome");
 			DynoQueueDAO queueDao = new DynoQueueDAO(dynoConn, dynoConn, ss, config);
 
 			bind(MetadataDAO.class).to(RedisMetadataDAO.class);

--- a/server/src/main/java/com/netflix/conductor/server/ServerModule.java
+++ b/server/src/main/java/com/netflix/conductor/server/ServerModule.java
@@ -91,7 +91,7 @@ public class ServerModule extends AbstractModule {
 		} else {
 			String localDC = localRack;
 			localDC = localDC.replaceAll(region, "");
-			SingleShardSupplier ss = new SingleShardSupplier("custome");
+			SingleShardSupplier ss = new SingleShardSupplier("custom");
 			DynoQueueDAO queueDao = new DynoQueueDAO(dynoConn, dynoConn, ss, config);
 
 			bind(MetadataDAO.class).to(RedisMetadataDAO.class);


### PR DESCRIPTION
- Instead of DynoShardSupplier which is based on dynomite nodes being passed in configuration use SingleShardSupplier. When we use DynoShardSupplier conductor ends up sharding across all the replica nodes, but only reads from one leaving the other unserviced. Confirmed data is still replicated to all redis nodes. 
- Truncate archive JSON field to be less than 32KB. If we need to save more we need to use an index mapping and set the field to not be indexed. Currently we use dynamic mapping. 
