### PR TITLE
Support AWS ElasticSearch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ subprojects {
 
     dependencyManagement {
       imports {
-        mavenBom 'com.amazonaws:aws-java-sdk-bom:1.11.228'
+        mavenBom 'com.amazonaws:aws-java-sdk-bom:1.11.269'
         mavenBom 'vc.inreach.aws:aws-signing-request-interceptor:0.0.20'
         mavenBom 'com.google.guava:guava:18.0'
       }

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
 }
 plugins {
     id 'nebula.netflixoss' version '3.6.0'
+    id "io.spring.dependency-management" version "1.0.4.RELEASE"
 }
 
 // Establish version and status
@@ -30,6 +31,15 @@ subprojects {
     apply plugin: 'idea'
     apply plugin: 'eclipse'
     apply plugin: 'project-report'
+    apply plugin: "io.spring.dependency-management"
+
+    dependencyManagement {
+      imports {
+        mavenBom 'com.amazonaws:aws-java-sdk-bom:1.11.228'
+        mavenBom 'vc.inreach.aws:aws-signing-request-interceptor:0.0.20'
+        mavenBom 'com.google.guava:guava:18.0'
+      }
+    }
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8

--- a/es-restclient-persistence/build.gradle
+++ b/es-restclient-persistence/build.gradle
@@ -7,8 +7,8 @@ dependencies {
 	compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.9.1'
 	compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.9.1'
 
-	compile 'org.elasticsearch:elasticsearch:5.3.0'
-	compile 'org.elasticsearch.client:transport:5.3.0'
+	compile 'org.elasticsearch:elasticsearch:5.6.0'
+	compile 'org.elasticsearch.client:transport:5.6.0'
 	compile 'org.elasticsearch.client:elasticsearch-rest-client:5.6.0'
 	compile 'org.elasticsearch.client:elasticsearch-rest-high-level-client:5.6.0'
 	compile 'commons-io:commons-io:2.4'

--- a/es-restclient-persistence/build.gradle
+++ b/es-restclient-persistence/build.gradle
@@ -13,4 +13,8 @@ dependencies {
 	compile 'org.elasticsearch.client:elasticsearch-rest-high-level-client:5.6.0'
 	compile 'commons-io:commons-io:2.4'
 
+        //Dependencies for signing ES requests with AWS keys
+        compile 'com.amazonaws:aws-java-sdk-s3:1.11.228'
+        compile 'vc.inreach.aws:aws-signing-request-interceptor:0.0.20'
+        compile 'com.google.guava:guava:18.0'
 }

--- a/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticsearchModule.java
+++ b/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticsearchModule.java
@@ -87,7 +87,7 @@ public class ElasticsearchModule extends AbstractModule {
             if (isAwsEs) 
                     hostList.add(new HttpHost(hostname, hostport, "https"));
 	    else 
-		    hostList.add(new HttpHost(hostname, hostport));
+		    hostList.add(new HttpHost(hostname, hostport, "http"));
             log.info("Adding Host: " + hostname + ":" + hostport);
         }
         

--- a/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticsearchModule.java
+++ b/es-restclient-persistence/src/main/java/com/netflix/conductor/dao/esrest/index/ElasticsearchModule.java
@@ -65,7 +65,7 @@ public class ElasticsearchModule extends AbstractModule {
 		}
         boolean isAwsEs = false; 
         String awsEs = config.getProperty("workflow.elasticsearch.aws", "");
-        if(awsEs.equalsIgnoreCase("y")) {
+        if(awsEs.equalsIgnoreCase("true")) {
                 log.info("workflow.elasticsearch.aws is enabled, requests will be signed with AWS keys.");
                 isAwsEs = true;
         }


### PR DESCRIPTION
Add an option to configure AWS ES, when the option is enabled get AWS default credentials and add interceptor to sign the requests. 