### PR TITLE
Adds default to notification queue size, 50

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/publisher/TaskStatusPublisher.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/publisher/TaskStatusPublisher.java
@@ -14,7 +14,7 @@ public class TaskStatusPublisher implements TaskStatusListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TaskStatusPublisher.class);
     private static final String NOTIFICATION_TYPE = "workflow/TaskNotifications";
-    private static final Integer QDEPTH = Integer.parseInt(System.getenv("ENV_TASK_NOTIFICATION_QUEUE_SIZE"));
+    private static final Integer QDEPTH = Integer.parseInt(System.getenv().getOrDefault("ENV_TASK_NOTIFICATION_QUEUE_SIZE", "50"));
     private BlockingQueue<Task> blockingQueue = new LinkedBlockingDeque<>(QDEPTH);
 
     class ExceptionHandler implements Thread.UncaughtExceptionHandler

--- a/contribs/src/main/java/com/netflix/conductor/contribs/publisher/WorkflowStatusPublisher.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/publisher/WorkflowStatusPublisher.java
@@ -14,7 +14,7 @@ public class WorkflowStatusPublisher implements WorkflowStatusListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WorkflowStatusPublisher.class);
     private static final String NOTIFICATION_TYPE = "workflow/WorkflowNotifications";
-    private static final Integer QDEPTH = Integer.parseInt(System.getenv("ENV_WORKFLOW_NOTIFICATION_QUEUE_SIZE"));
+    private static final Integer QDEPTH = Integer.parseInt(System.getenv().getOrDefault("ENV_WORKFLOW_NOTIFICATION_QUEUE_SIZE", "50"));
     private BlockingQueue<Workflow> blockingQueue = new LinkedBlockingDeque<>(QDEPTH);
 
     class ExceptionHandler implements Thread.UncaughtExceptionHandler


### PR DESCRIPTION
Adds default value to notification queue in case environment parameter is not present.
ENV_TASK_NOTIFICATION_QUEUE_SIZE, if not present defaults to 50
ENV_WORKFLOW_NOTIFICATION_QUEUE_SIZE, if not present defaults to 50