### PR TITLE
Fix release tag

### DIFF
--- a/.github/workflows/publish-jar.yml
+++ b/.github/workflows/publish-jar.yml
@@ -22,7 +22,7 @@ jobs:
         run: ./gradlew conductor-server:shadowJar --stacktrace
       - name: Create build tag
         run: |
-          echo "::set-output name=TAG::$(git describe --abbrev=0 --tags)-build.${{ github.run_number }}+${{ github.sha }}"
+          echo "::set-output name=TAG::$(git describe --abbrev=0 --tags --exclude '*-build.*')-build.${{ github.run_number }}+${{ github.sha }}"
         id: tag
       - name: Upload conductor-server JAR
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
Exclude the 'build' tags from the tags considered by `git describe`
to avoid recursively appending tags.